### PR TITLE
fix(otel): fix span leaks and use BatchSpanProcessor for Grafana export

### DIFF
--- a/app/api/shorten/route.ts
+++ b/app/api/shorten/route.ts
@@ -25,6 +25,7 @@ export async function POST(request: NextRequest) {
       const result = validateShortenRequest(body);
 
       if (!result.success) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: result.error.errors[0].message });
         return NextResponse.json(
           { error: result.error.errors[0].message },
           { status: 400 }
@@ -60,6 +61,7 @@ export async function POST(request: NextRequest) {
       // 安全確認
       const safetyResult = await checkUrlSafety(url);
       if (!safetyResult.safe) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: `Unsafe URL: ${safetyResult.threatType}` });
         return NextResponse.json(
           {
             error: "このURLは安全ではない可能性があるため登録できません",

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,5 @@
 import { registerOTel } from "@vercel/otel";
-import { ConsoleSpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { ConsoleSpanExporter, SimpleSpanProcessor, BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 
 export function register() {
@@ -12,6 +12,10 @@ export function register() {
       spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
     });
   } else {
+    if (!process.env.GRAFANA_AUTH_TOKEN) {
+      console.warn("GRAFANA_AUTH_TOKEN is not set. OpenTelemetry traces will not be sent to Grafana.");
+    }
+
     console.log("Initializing OpenTelemetry with OTLPTraceExporter for Grafana (Production Mode)");
     const exporter = new OTLPTraceExporter({
       url: process.env.GRAFANA_OTLP_ENDPOINT || "https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp/v1/traces",
@@ -22,7 +26,7 @@ export function register() {
 
     registerOTel({
       serviceName: "my-url-shortener",
-      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      spanProcessors: [new BatchSpanProcessor(exporter)],
     });
   }
 }

--- a/lib/api/safe-browsing.ts
+++ b/lib/api/safe-browsing.ts
@@ -4,62 +4,64 @@ const tracer = trace.getTracer("url-shortener");
 
 export async function checkUrlSafety(url: string): Promise<{ safe: boolean; threatType?: string }> {
   return tracer.startActiveSpan("check-url-safety", async (span) => {
-  const apiKey = process.env.GOOGLE_SAFE_BROWSING_API_KEY;
-  if (!apiKey) {
-    console.warn("GOOGLE_SAFE_BROWSING_API_KEY is not set. Skipping safety check.");
-    return { safe: true };
-  }
+    try {
+      const apiKey = process.env.GOOGLE_SAFE_BROWSING_API_KEY;
+      if (!apiKey) {
+        console.warn("GOOGLE_SAFE_BROWSING_API_KEY is not set. Skipping safety check.");
+        return { safe: true };
+      }
 
-  // v5alpha1 (v5) endpoint
-  const endpoint = `https://safebrowsing.googleapis.com/v5alpha1/urls:search?key=${apiKey}`;
+      // v5alpha1 (v5) endpoint
+      const endpoint = `https://safebrowsing.googleapis.com/v5alpha1/urls:search?key=${apiKey}`;
 
-  try {
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        urls: [url],
-      }),
-    });
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          urls: [url],
+        }),
+      });
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      console.error("Google Safe Browsing API error:", response.status, errorData);
-      // APIエラー時は安全とみなして続行（フェイルセーフ）
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        console.error("Google Safe Browsing API error:", response.status, errorData);
+        // APIエラー時は安全とみなして続行（フェイルセーフ）
+        return { safe: true };
+      }
+
+      interface SafeBrowsingMatch {
+        threatType: string;
+        url: string;
+      }
+
+      interface SafeBrowsingResponse {
+        matches?: SafeBrowsingMatch[];
+      }
+
+      const data = (await response.json()) as SafeBrowsingResponse;
+
+      if (data.matches && data.matches.length > 0) {
+        span.setAttribute("safe", false);
+        span.setAttribute("threat_type", data.matches[0].threatType);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: `Threat detected: ${data.matches[0].threatType}` });
+        return {
+          safe: false,
+          threatType: data.matches[0].threatType,
+        };
+      }
+
+      span.setAttribute("safe", true);
+      span.setStatus({ code: SpanStatusCode.OK });
       return { safe: true };
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : "Unknown error" });
+      console.error("Google Safe Browsing API connection error:", error);
+      return { safe: true };
+    } finally {
+      span.end();
     }
-
-    interface SafeBrowsingMatch {
-      threatType: string;
-      url: string;
-    }
-
-    interface SafeBrowsingResponse {
-      matches?: SafeBrowsingMatch[];
-    }
-
-    const data = (await response.json()) as SafeBrowsingResponse;
-
-    if (data.matches && data.matches.length > 0) {
-      span.setAttribute("safe", false);
-      span.setAttribute("threat_type", data.matches[0].threatType);
-      return {
-        safe: false,
-        threatType: data.matches[0].threatType,
-      };
-    }
-
-    span.setAttribute("safe", true);
-    span.setStatus({ code: SpanStatusCode.OK });
-    return { safe: true };
-  } catch (error) {
-    span.recordException(error as Error);
-    console.error("Google Safe Browsing API connection error:", error);
-    return { safe: true };
-  } finally {
-    span.end();
-  }
   });
 }


### PR DESCRIPTION
- safe-browsing.ts: wrap entire body in try/finally so span.end() is
  always called (previously leaked when GOOGLE_SAFE_BROWSING_API_KEY
  was unset); also set SpanStatusCode.ERROR on threat detection and
  catch block
- instrumentation.ts: replace SimpleSpanProcessor with BatchSpanProcessor
  in production for reliable export; add warning when GRAFANA_AUTH_TOKEN
  is missing so auth failures are visible in logs
- shorten/route.ts: set SpanStatusCode.ERROR on 400 validation and 403
  unsafe-URL responses so error spans are correctly reported in Grafana

https://claude.ai/code/session_017tp6YZi4yn2ffe7HgD7mFH