### PR TITLE
fix: use resourceFromAttributes() for @opentelemetry/resources v2 compatibility

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -5,7 +5,7 @@ import {
   ConsoleSpanExporter,
 } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 export function register() {
@@ -14,7 +14,7 @@ export function register() {
     process.env.NODE_ENV === "development";
 
   const provider = new BasicTracerProvider({
-    resource: new Resource({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
   });
 
   if (isDev) {


### PR DESCRIPTION
## Summary

- `@opentelemetry/resources` v2.x で `Resource` クラスが廃止され `resourceFromAttributes()` に変更された
- ビルドエラー: `'Resource' is not exported from '@opentelemetry/resources'`

## Test plan

- [ ] CIビルドが通ることを確認
- [ ] デプロイ後 `wrangler tail` でエラーが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)