### PR TITLE
fix: update BasicTracerProvider for @opentelemetry/sdk-trace-base v2 API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# my-url-shortener
+
+Cloudflare Workers (opennextjs-cloudflare) にデプロイするNext.js製のURL短縮サービス。
+
+## 技術スタック
+
+- **ランタイム**: Cloudflare Workers (V8 isolate, Node.jsではない)
+- **フレームワーク**: Next.js 15 + opennextjs-cloudflare
+- **DB**: Cloudflare D1 (SQLite)
+- **キャッシュ**: Cloudflare KV
+- **可観測性**: OpenTelemetry → Grafana Cloud (Tempo)
+
+## OpenTelemetry
+
+### 注意事項
+
+Cloudflare Workers はNode.js互換ではなくV8 isolate環境のため、以下のパッケージは使用不可：
+- `@vercel/otel` — Node.js専用、`instrumentation.ts` のロードに失敗する
+- `BasicTracerProvider.addSpanProcessor()` — v2.xで廃止
+- `BasicTracerProvider.register()` — v2.xで廃止
+- `new Resource()` — `@opentelemetry/resources` v2.xで廃止
+
+### 現在の実装 (`instrumentation.ts`)
+
+`@opentelemetry/sdk-trace-base` v2.x の正しいAPI：
+- **Resource**: `resourceFromAttributes()` を使用
+- **SpanProcessor**: コンストラクタの `spanProcessors: []` で渡す
+- **グローバル登録**: `trace.setGlobalTracerProvider(provider)` を使用
+
+### OTel変更時の確認手順
+
+1. **ローカルビルド確認** — デプロイ前に必ず手元でビルドが通るか確認する：
+   ```bash
+   pnpm build
+   ```
+
+2. **デプロイ後のランタイム確認** — `wrangler tail` でOTelが正常初期化されているか確認：
+   ```bash
+   wrangler tail my-url-shortener --env production --format pretty
+   ```
+   リクエストを送って以下がないことを確認：
+   - `Failed to prepare server Error: An error occurred while loading the instrumentation hook`
+
+3. **Grafana Cloud確認** — Explore → Tempo でサービス名 `my-url-shortener` のtraceを検索
+
+### console.logの見方
+
+本番の `console.log` はVercelではなく **Cloudflare Workers Logs** に出力される。
+`wrangler tail` または Cloudflare Dashboard → Workers → Logs で確認。

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -7,18 +7,19 @@ import {
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { trace } from "@opentelemetry/api";
 
 export function register() {
   const isDev =
     process.env.ENVIRONMENT === "development" ||
     process.env.NODE_ENV === "development";
 
-  const provider = new BasicTracerProvider({
-    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
-  });
-
   if (isDev) {
-    provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+    const provider = new BasicTracerProvider({
+      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
+      spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
+    });
+    trace.setGlobalTracerProvider(provider);
   } else {
     if (!process.env.GRAFANA_AUTH_TOKEN) {
       console.warn(
@@ -35,9 +36,13 @@ export function register() {
       },
     });
 
-    provider.addSpanProcessor(new BatchSpanProcessor(exporter));
-    provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+    const provider = new BasicTracerProvider({
+      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
+      spanProcessors: [
+        new BatchSpanProcessor(exporter),
+        new SimpleSpanProcessor(new ConsoleSpanExporter()),
+      ],
+    });
+    trace.setGlobalTracerProvider(provider);
   }
-
-  provider.register();
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,6 +3,7 @@ import {
   BatchSpanProcessor,
   SimpleSpanProcessor,
   ConsoleSpanExporter,
+  type SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
@@ -14,35 +15,34 @@ export function register() {
     process.env.ENVIRONMENT === "development" ||
     process.env.NODE_ENV === "development";
 
+  const resource = resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" });
+
   if (isDev) {
     const provider = new BasicTracerProvider({
-      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
+      resource,
       spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
     });
     trace.setGlobalTracerProvider(provider);
   } else {
-    if (!process.env.GRAFANA_AUTH_TOKEN) {
+    const spanProcessors: SpanProcessor[] = [new SimpleSpanProcessor(new ConsoleSpanExporter())];
+
+    if (process.env.GRAFANA_AUTH_TOKEN) {
+      const exporter = new OTLPTraceExporter({
+        url:
+          process.env.GRAFANA_OTLP_ENDPOINT ||
+          "https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp/v1/traces",
+        headers: {
+          Authorization: `Basic ${process.env.GRAFANA_AUTH_TOKEN}`,
+        },
+      });
+      spanProcessors.unshift(new BatchSpanProcessor(exporter));
+    } else {
       console.warn(
         "GRAFANA_AUTH_TOKEN is not set. OpenTelemetry traces will not be sent to Grafana."
       );
     }
 
-    const exporter = new OTLPTraceExporter({
-      url:
-        process.env.GRAFANA_OTLP_ENDPOINT ||
-        "https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp/v1/traces",
-      headers: {
-        Authorization: `Basic ${process.env.GRAFANA_AUTH_TOKEN}`,
-      },
-    });
-
-    const provider = new BasicTracerProvider({
-      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "my-url-shortener" }),
-      spanProcessors: [
-        new BatchSpanProcessor(exporter),
-        new SimpleSpanProcessor(new ConsoleSpanExporter()),
-      ],
-    });
+    const provider = new BasicTracerProvider({ resource, spanProcessors });
     trace.setGlobalTracerProvider(provider);
   }
 }


### PR DESCRIPTION
## Summary

v2.x の破壊的変更への対応：
- `addSpanProcessor()` 廃止 → コンストラクタの `spanProcessors` 配列に移動
- `provider.register()` 廃止 → `trace.setGlobalTracerProvider()` に変更

## Test plan

- [ ] CIビルドが通ることを確認
- [ ] デプロイ後 `wrangler tail` でOTelエラーが消えることを確認
- [ ] Grafana Cloud Tempo でtraceが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)