### PR TITLE
fix: declare OTel phantom dependencies to unbreak CI deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@opennextjs/cloudflare": "^1.16.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.211.0",
+    "@opentelemetry/otlp-exporter-base": "^0.211.0",
+    "@opentelemetry/otlp-transformer": "^0.211.0",
     "@opentelemetry/resources": "^2.5.0",
     "@opentelemetry/sdk-trace-base": "^2.5.0",
     "@opentelemetry/semantic-conventions": "^1.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.211.0
         version: 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base':
+        specifier: ^0.211.0
+        version: 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer':
+        specifier: ^0.211.0
+        version: 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
         specifier: ^2.5.0
         version: 2.5.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## 問題

mainへのデプロイ(GitHub Actions)が **lib/otel 導入以降の約3週間、毎回失敗していた**(#49, #50, #52 のマージ時すべて):

```
./lib/otel/init.ts:93:48
Type error: Argument of type 'WorkersOTLPTraceExporter' is not assignable to parameter of type 'SpanExporter'.
  Type 'WorkersOTLPTraceExporter' is missing the following properties from type 'SpanExporter': export, shutdown
```

## 原因

`lib/otel/workers-otlp-trace-exporter.ts` が `@opentelemetry/otlp-exporter-base` と `@opentelemetry/otlp-transformer` を直接importしているのに、package.json には書かれていなかった(**phantom dependency**、`exporter-trace-otlp-http` の推移的依存)。

- **CI(クリーンインストール)**: これらが root の sdk-trace-base とは別インスタンスとして解決され、`ReadableSpan`/`SpanExporter` の型アイデンティティが一致せず型エラー
- **ローカルで再現しなかった理由**: リポジトリの node_modules に過去のインストールでhoistされた古いコピーが残っており、それがimportを満たしていた(worktree内ビルドも親の node_modules にフォールバックするため気づけない)

## 修正

直接importしている2パッケージを依存として宣言(lockfile上は既存の 0.211.0 にdedupeされるだけ):

```diff
+    "@opentelemetry/otlp-exporter-base": "^0.211.0",
+    "@opentelemetry/otlp-transformer": "^0.211.0",
```

## 検証

1. リポジトリ外の隔離ディレクトリに `pnpm install --frozen-lockfile` でクリーンインストール → **CIの型エラーを完全再現**
2. 本修正を適用 → 同環境で `pnpm build` 成功
3. worktree内でも `pnpm type-check` / MCPテスト 11/11 pass

マージ後、Deploy workflow が初めて成功するはずなので要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)