### PR TITLE
feat: チャット操作インターフェイスを追加 (UNI-102)

### DIFF
--- a/__tests__/ChatInterface.test.tsx
+++ b/__tests__/ChatInterface.test.tsx
@@ -35,15 +35,12 @@ afterEach(() => {
 });
 
 describe("ChatInterface without the Prompt API", () => {
-  it("shows the fallback panel with setup instructions", async () => {
+  it("shows an error message", async () => {
     render(<ChatInterface onShorten={vi.fn()} />);
 
     expect(
       screen.getByText("このブラウザではオンデバイスAI (Prompt API) を利用できません。"),
     ).toBeDefined();
-    expect(screen.getByText("chrome://flags/#prompt-api-for-gemini-nano")).toBeDefined();
-    expect(screen.getByText("chrome://flags/#optimization-guide-on-device-model")).toBeDefined();
-    expect(screen.getByText("chrome://components")).toBeDefined();
   });
 });
 

--- a/__tests__/ChatInterface.test.tsx
+++ b/__tests__/ChatInterface.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import ChatInterface from "@/app/components/ChatInterface";
+
+// MCPブリッジはネットワークに出るためモックする（SDK自体もロードさせない）
+const { mockCreateMcpClient, mockBuildPromptApiTools } = vi.hoisted(() => ({
+  mockCreateMcpClient: vi.fn(),
+  mockBuildPromptApiTools: vi.fn(),
+}));
+
+vi.mock("@/lib/chat/mcp-bridge", () => ({
+  createMcpClient: mockCreateMcpClient,
+  buildPromptApiTools: mockBuildPromptApiTools,
+}));
+
+type GlobalWithLanguageModel = typeof globalThis & { LanguageModel?: unknown };
+
+function streamOf(chunks: string[]): ReadableStream<string> {
+  return new ReadableStream<string>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateMcpClient.mockResolvedValue({});
+  mockBuildPromptApiTools.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  delete (globalThis as GlobalWithLanguageModel).LanguageModel;
+});
+
+describe("ChatInterface without the Prompt API", () => {
+  it("shows the fallback panel with setup instructions", async () => {
+    render(<ChatInterface onShorten={vi.fn()} />);
+
+    expect(
+      screen.getByText("このブラウザではオンデバイスAI (Prompt API) を利用できません。"),
+    ).toBeDefined();
+    expect(screen.getByText("chrome://flags/#prompt-api-for-gemini-nano")).toBeDefined();
+    expect(screen.getByText("chrome://flags/#optimization-guide-on-device-model")).toBeDefined();
+    expect(screen.getByText("chrome://components")).toBeDefined();
+  });
+});
+
+describe("ChatInterface with a mocked Prompt API", () => {
+  const destroy = vi.fn();
+  let promptStreaming: ReturnType<typeof vi.fn>;
+  let create: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    promptStreaming = vi.fn().mockReturnValue(streamOf(["短縮", "しました"]));
+    create = vi.fn().mockResolvedValue({
+      promptStreaming,
+      prompt: vi.fn(),
+      inputUsage: 0,
+      inputQuota: 1024,
+      destroy,
+    });
+    (globalThis as GlobalWithLanguageModel).LanguageModel = {
+      availability: vi.fn().mockResolvedValue("available"),
+      create,
+    };
+  });
+
+  it("streams the assistant reply after sending a message", async () => {
+    render(<ChatInterface onShorten={vi.fn()} />);
+
+    // availability() 解決後にチャットUIが表示される
+    const input = await screen.findByLabelText("メッセージを入力");
+    fireEvent.change(input, { target: { value: "https://example.com を短縮して" } });
+    fireEvent.submit(input.closest("form")!);
+
+    // ユーザーのメッセージが表示される
+    expect(await screen.findByText("https://example.com を短縮して")).toBeDefined();
+
+    // ストリーミングされたアシスタントの応答が結合されて表示される
+    expect(await screen.findByText("短縮しました")).toBeDefined();
+
+    // セッションはシステムプロンプトとMCP由来のツールで生成される
+    expect(create).toHaveBeenCalledTimes(1);
+    const options = create.mock.calls[0][0];
+    expect(options.initialPrompts[0].role).toBe("system");
+    expect(options.initialPrompts[0].content).toContain("shorten_url");
+    expect(mockCreateMcpClient).toHaveBeenCalledTimes(1);
+    expect(mockBuildPromptApiTools).toHaveBeenCalledTimes(1);
+    expect(promptStreaming).toHaveBeenCalledWith("https://example.com を短縮して");
+  });
+
+  it("destroys the session on unmount", async () => {
+    const { unmount } = render(<ChatInterface onShorten={vi.fn()} />);
+
+    const input = await screen.findByLabelText("メッセージを入力");
+    fireEvent.change(input, { target: { value: "テスト" } });
+    fireEvent.submit(input.closest("form")!);
+    await screen.findByText("短縮しました");
+
+    unmount();
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/Home.test.tsx
+++ b/__tests__/Home.test.tsx
@@ -114,6 +114,29 @@ describe("Home Page", () => {
     }, { timeout: 2000 });
   });
 
+  describe("Tab switching", () => {
+    it("shows the form tab by default", () => {
+      render(<Home />);
+      expect(screen.getByRole("tab", { name: "フォーム" }).getAttribute("aria-selected")).toBe("true");
+      expect(screen.getByRole("tab", { name: "チャット" }).getAttribute("aria-selected")).toBe("false");
+      expect(screen.getByText("URL短縮サービス")).toBeDefined();
+    });
+
+    it("switches to the chat tab and shows the chat panel", async () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("tab", { name: "チャット" }));
+
+      expect(screen.getByRole("tab", { name: "チャット" }).getAttribute("aria-selected")).toBe("true");
+      // チャットパネルが表示される（jsdomにはLanguageModelがないため未対応の案内になる）
+      expect(await screen.findByText("チャットで短縮")).toBeDefined();
+      expect(screen.getByText("chrome://flags/#prompt-api-for-gemini-nano")).toBeDefined();
+      // フォームパネルはhiddenで保持される
+      expect(document.getElementById("panel-form")?.hidden).toBe(true);
+      expect(document.getElementById("panel-chat")?.hidden).toBe(false);
+    });
+  });
+
   describe("History Feature", () => {
     it("saves URL to history after successful shortening", async () => {
       const shortCode = "hist123";

--- a/__tests__/chat-mcp-route.test.ts
+++ b/__tests__/chat-mcp-route.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+// mcp-handler は node:http / node:net 等のビルトインを使うため、jsdomではなくnode環境で実行する。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { UrlRecord } from "@/lib/core/repository";
+
+const { mockService, mockEnforceIpRateLimit } = vi.hoisted(() => ({
+  mockService: { create: vi.fn(), get: vi.fn(), delete: vi.fn() },
+  mockEnforceIpRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/core/build", () => ({
+  buildService: () => mockService,
+}));
+
+vi.mock("@/lib/api/rate-limit", () => ({
+  enforceIpRateLimit: mockEnforceIpRateLimit,
+}));
+
+import { POST, GET, DELETE } from "@/app/api/chat/mcp/route";
+
+const record: UrlRecord = {
+  id: 1,
+  longUrl: "https://example.com/",
+  shortCode: "abc123",
+  createdAt: "2026-05-22",
+};
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id?: number | string;
+  result?: {
+    tools?: Array<{ name: string; description?: string }>;
+    content?: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+/** 認証ヘッダなしのMCPリクエストを組み立てる（チャットUIからの呼び出しを模す）。 */
+function mcpRequest(body: unknown) {
+  return new NextRequest("https://sho.rt/api/chat/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Streamable HTTPのレスポンス(JSONまたはSSE)からJSON-RPCメッセージを取り出す。 */
+async function readJsonRpc(res: Response): Promise<JsonRpcResponse> {
+  const text = await res.text();
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    const dataLine = text
+      .split("\n")
+      .find((line) => line.startsWith("data: "));
+    if (!dataLine) throw new Error(`No SSE data in response: ${text}`);
+    return JSON.parse(dataLine.slice(6)) as JsonRpcResponse;
+  }
+  return JSON.parse(text) as JsonRpcResponse;
+}
+
+function toolsListBody(id = 1) {
+  return { jsonrpc: "2.0", id, method: "tools/list", params: {} };
+}
+
+function toolsCallBody(name: string, args: Record<string, unknown>, id = 2) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name, arguments: args },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnforceIpRateLimit.mockResolvedValue(null);
+});
+
+describe("POST /api/chat/mcp rate limiting", () => {
+  it("returns the 429 response when the IP rate limiter rejects the request", async () => {
+    mockEnforceIpRateLimit.mockResolvedValue(new NextResponse(null, { status: 429 }));
+    const res = await POST(mcpRequest(toolsListBody()));
+    expect(res.status).toBe(429);
+  });
+
+  it("passes env and the request to the IP rate limiter", async () => {
+    const request = mcpRequest(toolsListBody());
+    await POST(request);
+    expect(mockEnforceIpRateLimit).toHaveBeenCalledWith(expect.anything(), request);
+  });
+});
+
+describe("POST /api/chat/mcp tools/list (no auth header)", () => {
+  it("lists the shorten_url and resolve_url tools without authentication", async () => {
+    const res = await POST(mcpRequest(toolsListBody()));
+    expect(res.status).toBe(200);
+    const message = await readJsonRpc(res);
+    const names = message.result?.tools?.map((tool) => tool.name);
+    expect(names).toContain("shorten_url");
+    expect(names).toContain("resolve_url");
+    expect(names).toHaveLength(2);
+  });
+});
+
+describe("POST /api/chat/mcp tools/call (no auth header)", () => {
+  it("shortens a URL via shorten_url", async () => {
+    mockService.create.mockResolvedValue({ record, isExisting: false });
+    const res = await POST(
+      mcpRequest(toolsCallBody("shorten_url", { url: "https://example.com" })),
+    );
+    expect(res.status).toBe(200);
+    const message = await readJsonRpc(res);
+    expect(message.result?.isError).toBeFalsy();
+    const payload = JSON.parse(message.result!.content![0].text) as Record<string, unknown>;
+    expect(payload).toEqual({
+      code: "abc123",
+      short_url: "https://sho.rt/abc123",
+      long_url: "https://example.com/",
+      isExisting: false,
+    });
+  });
+
+  it("resolves a code via resolve_url", async () => {
+    mockService.get.mockResolvedValue(record);
+    const res = await POST(mcpRequest(toolsCallBody("resolve_url", { code: "abc123" })));
+    const message = await readJsonRpc(res);
+    expect(message.result?.isError).toBeFalsy();
+    const payload = JSON.parse(message.result!.content![0].text) as Record<string, unknown>;
+    expect(payload).toEqual({
+      code: "abc123",
+      short_url: "https://sho.rt/abc123",
+      long_url: "https://example.com/",
+    });
+  });
+});
+
+describe("unsupported methods on /api/chat/mcp", () => {
+  it("returns 405 for GET", async () => {
+    const res = await GET();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+
+  it("returns 405 for DELETE", async () => {
+    const res = await DELETE();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+});

--- a/__tests__/mcp-bridge.test.ts
+++ b/__tests__/mcp-bridge.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const { MockClient, MockTransport, mockConnect } = vi.hoisted(() => {
+  const mockConnect = vi.fn();
+  return {
+    mockConnect,
+    MockClient: vi.fn(function (this: { connect: typeof mockConnect }) {
+      this.connect = mockConnect;
+    }),
+    MockTransport: vi.fn(),
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: MockClient,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: MockTransport,
+}));
+
+import { createMcpClient, buildPromptApiTools } from "@/lib/chat/mcp-bridge";
+
+/** listTools / callTool だけを持つ最小のクライアントスタブを作る。 */
+function stubClient(overrides: { listTools?: unknown; callTool?: unknown } = {}) {
+  return {
+    listTools: vi.fn().mockResolvedValue(
+      overrides.listTools ?? {
+        tools: [
+          {
+            name: "shorten_url",
+            description: "URLを短縮します",
+            inputSchema: {
+              $schema: "http://json-schema.org/draft-07/schema#",
+              additionalProperties: false,
+              type: "object",
+              properties: { url: { type: "string", description: "短縮したいURL" } },
+              required: ["url"],
+            },
+          },
+        ],
+      },
+    ),
+    callTool: vi.fn().mockResolvedValue(overrides.callTool ?? { content: [] }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+});
+
+describe("createMcpClient", () => {
+  it("connects a Client to /api/chat/mcp without auth", async () => {
+    const client = await createMcpClient();
+    expect(MockClient).toHaveBeenCalledWith({ name: "url-shortener-chat", version: "1.0.0" });
+    expect(MockTransport).toHaveBeenCalledTimes(1);
+    const url = MockTransport.mock.calls[0][0] as URL;
+    expect(url.pathname).toBe("/api/chat/mcp");
+    expect(url.origin).toBe(window.location.origin);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(client).toBeInstanceOf(MockClient);
+  });
+});
+
+describe("buildPromptApiTools", () => {
+  it("maps MCP tools to Prompt API tools and strips schema meta keys", async () => {
+    const client = stubClient();
+    const tools = await buildPromptApiTools(client as unknown as Client, vi.fn());
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("shorten_url");
+    expect(tools[0].description).toBe("URLを短縮します");
+    expect(tools[0].inputSchema).toEqual({
+      type: "object",
+      properties: { url: { type: "string", description: "短縮したいURL" } },
+      required: ["url"],
+    });
+    expect(tools[0].inputSchema).not.toHaveProperty("$schema");
+    expect(tools[0].inputSchema).not.toHaveProperty("additionalProperties");
+  });
+
+  it("joins text content items into a single string on execute", async () => {
+    const client = stubClient({
+      callTool: {
+        content: [
+          { type: "text", text: "1行目" },
+          { type: "image", data: "..." },
+          { type: "text", text: "2行目" },
+        ],
+      },
+    });
+    const tools = await buildPromptApiTools(client as unknown as Client, vi.fn());
+
+    const result = await tools[0].execute({ url: "https://example.com" });
+    expect(result).toBe("1行目\n2行目");
+    expect(client.callTool).toHaveBeenCalledWith({
+      name: "shorten_url",
+      arguments: { url: "https://example.com" },
+    });
+  });
+
+  it("prefixes the result with エラー: when the tool returns isError", async () => {
+    const client = stubClient({
+      callTool: {
+        isError: true,
+        content: [{ type: "text", text: "指定された短縮コードは存在しません" }],
+      },
+    });
+    const tools = await buildPromptApiTools(client as unknown as Client, vi.fn());
+
+    const result = await tools[0].execute({ url: "https://example.com" });
+    expect(result).toBe("エラー: 指定された短縮コードは存在しません");
+  });
+
+  it("returns a Japanese rate-limit message instead of throwing on a 429 transport error", async () => {
+    const client = stubClient();
+    client.callTool.mockRejectedValue(new Error("Error POSTing to endpoint (HTTP 429)"));
+    const onToolResult = vi.fn();
+    const tools = await buildPromptApiTools(client as unknown as Client, onToolResult);
+
+    const result = await tools[0].execute({ url: "https://example.com" });
+    expect(result).toBe("リクエストが多すぎます。しばらく待ってから再試行してください");
+    expect(onToolResult).toHaveBeenCalledWith({
+      toolName: "shorten_url",
+      args: { url: "https://example.com" },
+      resultText: "リクエストが多すぎます。しばらく待ってから再試行してください",
+      isError: true,
+    });
+  });
+
+  it("returns a Japanese error message instead of throwing on other transport errors", async () => {
+    const client = stubClient();
+    client.callTool.mockRejectedValue(new Error("fetch failed"));
+    const tools = await buildPromptApiTools(client as unknown as Client, vi.fn());
+
+    const result = await tools[0].execute({ url: "https://example.com" });
+    expect(result).toBe("ツールの呼び出しに失敗しました: fetch failed");
+  });
+
+  it("invokes onToolResult with a JSON-parsable payload for a successful shorten_url call", async () => {
+    const payload = {
+      code: "abc123",
+      short_url: "https://sho.rt/abc123",
+      long_url: "https://example.com/",
+      isExisting: false,
+    };
+    const client = stubClient({
+      callTool: { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] },
+    });
+    const onToolResult = vi.fn();
+    const tools = await buildPromptApiTools(client as unknown as Client, onToolResult);
+
+    await tools[0].execute({ url: "https://example.com" });
+
+    expect(onToolResult).toHaveBeenCalledTimes(1);
+    const event = onToolResult.mock.calls[0][0];
+    expect(event.toolName).toBe("shorten_url");
+    expect(event.args).toEqual({ url: "https://example.com" });
+    expect(event.isError).toBe(false);
+    expect(JSON.parse(event.resultText)).toEqual(payload);
+  });
+});

--- a/app/api/chat/mcp/route.ts
+++ b/app/api/chat/mcp/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { verifyApiKey } from "@/lib/api/api-key";
-import { enforceApiRateLimit } from "@/lib/api/rate-limit";
+import { enforceIpRateLimit } from "@/lib/api/rate-limit";
 import { apiError } from "@/lib/api/responses";
 import type { AppEnv } from "@/db";
 import { buildMcpHandler } from "@/lib/mcp/handler";
@@ -12,6 +11,11 @@ import { ensureOtelInitialized } from "@/lib/otel/init";
 
 const tracer = trace.getTracer("url-shortener");
 
+/**
+ * チャットUI（ブラウザのPrompt API）向けの認証なしMCPプロキシ。
+ * APIキーの代わりに、クライアントIP単位のレート制限で濫用を防ぐ。
+ * MCPハンドラ本体は /mcp と共通（lib/mcp/handler.ts）。
+ */
 export async function POST(request: NextRequest) {
   const { env, ctx } = (await getCloudflareContext()) as unknown as {
     env: AppEnv;
@@ -19,22 +23,17 @@ export async function POST(request: NextRequest) {
   };
   ensureOtelInitialized(env);
 
-  return tracer.startActiveSpan("mcp-request", async (span) => {
+  return tracer.startActiveSpan("chat-mcp-request", async (span) => {
     try {
       await setUserAttributes(span, request, env);
 
-      if (!verifyApiKey(request, env.API_KEY)) {
-        span.setStatus({ code: SpanStatusCode.ERROR, message: "Unauthorized" });
-        return apiError(401, "APIキーが無効です");
-      }
-
-      const rateLimited = await enforceApiRateLimit(env);
+      const rateLimited = await enforceIpRateLimit(env, request);
       if (rateLimited) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: "Rate limited" });
         return rateLimited;
       }
 
-      const handler = buildMcpHandler(env, request.nextUrl.origin);
+      const handler = buildMcpHandler(env, request.nextUrl.origin, "/api/chat");
       const response = await handler(request);
       span.setStatus({ code: SpanStatusCode.OK });
       return response;
@@ -44,7 +43,7 @@ export async function POST(request: NextRequest) {
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : "Unknown error",
       });
-      console.error("MCP request error:", error);
+      console.error("Chat MCP request error:", error);
       return apiError(500, "MCPリクエストの処理に失敗しました");
     } finally {
       span.end();

--- a/app/components/ChatInterface.tsx
+++ b/app/components/ChatInterface.tsx
@@ -33,7 +33,41 @@ const SYSTEM_PROMPT =
   "あなたはURL短縮アシスタントです。" +
   "URLの短縮を頼まれたら、必ず shorten_url ツールを使って短縮してください。" +
   "短縮コードから元のURLを調べるよう頼まれたら、必ず resolve_url ツールを使ってください。" +
-  "簡潔に日本語で答えてください。";
+  "URLを答えるときは、ツールの結果に含まれる short_url や long_url の値をそのまま使い、" +
+  "自分でURLを作ったり変えたりしてはいけません。" +
+  "マークダウン記法（バッククォートや**など）は使わず、プレーンテキストで簡潔に日本語で答えてください。";
+
+/**
+ * アシスタント応答の表示フォールバック。
+ * システムプロンプトでマークダウン禁止を指示しているが、小型モデルは従わないことが
+ * あるため、`...` で囲まれた部分はコード風スパンに整形して生のバッククォートを見せない。
+ */
+function AssistantText({ text }: { text: string }) {
+  const parts = text.split(/`([^`]+)`/g);
+  if (parts.length === 1) return <>{text}</>;
+  return (
+    <>
+      {parts.map((part, index) =>
+        index % 2 === 1 ? (
+          <code
+            key={index}
+            className="font-mono text-[0.9em] bg-muted/60 rounded px-1 break-all"
+          >
+            {part}
+          </code>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  );
+}
+
+/** 破棄済みセッションへの prompt 起因のエラーかどうかを判定する。 */
+function isSessionDestroyedError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "InvalidStateError") return true;
+  return error instanceof Error && /destroyed/i.test(error.message);
+}
 
 /** UrlShortener と同じローディングスピナー。 */
 function Spinner() {
@@ -72,6 +106,10 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
 
   const sessionRef = useRef<LanguageModelSession | null>(null);
   const toolsRef = useRef<LanguageModelTool[] | null>(null);
+  // アンマウント後の setState を防ぐためのガード
+  const isMountedRef = useRef(true);
+  // メッセージ追加時の自動スクロール先アンカー
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // マウント時にPrompt APIの利用可否を判定する
   useEffect(() => {
@@ -102,11 +140,19 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
 
   // アンマウント時にセッションを破棄する
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
+      isMountedRef.current = false;
       sessionRef.current?.destroy();
       sessionRef.current = null;
     };
   }, []);
+
+  // メッセージ追加・ストリーミング更新時に最下部へ自動スクロールする
+  // （jsdom には scrollIntoView がないため optional call にする）
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+  }, [messages, streamingText]);
 
   const handleToolResult = useCallback(
     (event: ToolResultEvent) => {
@@ -144,16 +190,26 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
       tools: toolsRef.current,
       monitor(m) {
         m.addEventListener("downloadprogress", (event) => {
-          const loaded = (event as LanguageModelDownloadProgressEvent).loaded;
-          setDownloadProgress(Math.round(loaded * 100));
+          const { loaded, total } = event as LanguageModelDownloadProgressEvent;
+          // 現行仕様では loaded は 0〜1 の進捗率。古い実装（バイト数 + total）にも対応する
+          const fraction = total && total > 0 ? loaded / total : loaded;
+          if (isMountedRef.current) {
+            setDownloadProgress(Math.round(Math.min(fraction, 1) * 100));
+          }
         });
       },
     });
+    // create() 中にアンマウントされていたらセッションをリークさせない
+    if (!isMountedRef.current) {
+      session.destroy();
+      throw new Error("チャットが閉じられたため初期化を中断しました");
+    }
     sessionRef.current = session;
     return session;
   }, [handleToolResult]);
 
   const failWithError = (error: unknown) => {
+    if (!isMountedRef.current) return;
     setErrorDetail(error instanceof Error ? error.message : String(error));
     setStatus("error");
   };
@@ -164,7 +220,7 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
     setStatus("downloading");
     try {
       await ensureSession();
-      setStatus("ready");
+      if (isMountedRef.current) setStatus("ready");
     } catch (error) {
       failWithError(error);
     }
@@ -184,32 +240,54 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
     } catch (error) {
       // セッション生成に失敗（tools未対応バージョン等）した場合はエラーパネルへ
       failWithError(error);
-      setSending(false);
+      if (isMountedRef.current) setSending(false);
       return;
     }
 
-    try {
-      setStreamingText("");
+    const runStream = async (s: LanguageModelSession): Promise<string> => {
       let accumulated = "";
-      const reader = session.promptStreaming(text).getReader();
+      const reader = s.promptStreaming(text).getReader();
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
         accumulated += value;
+        if (!isMountedRef.current) break;
         setStreamingText(accumulated);
       }
-      dispatch({ type: "append", message: { role: "assistant", text: accumulated } });
+      return accumulated;
+    };
+
+    try {
+      setStreamingText("");
+      let accumulated: string;
+      try {
+        accumulated = await runStream(session);
+      } catch (error) {
+        // セッションが破棄されていた場合（dev のホットリロード等）は
+        // 一度だけ作り直して再試行する
+        if (!isSessionDestroyedError(error)) throw error;
+        sessionRef.current = null;
+        session = await ensureSession();
+        accumulated = await runStream(session);
+      }
+      if (isMountedRef.current) {
+        dispatch({ type: "append", message: { role: "assistant", text: accumulated } });
+      }
     } catch (error) {
-      dispatch({
-        type: "append",
-        message: {
-          role: "assistant",
-          text: `エラーが発生しました: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      });
+      if (isMountedRef.current) {
+        dispatch({
+          type: "append",
+          message: {
+            role: "assistant",
+            text: `エラーが発生しました: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        });
+      }
     } finally {
-      setStreamingText(null);
-      setSending(false);
+      if (isMountedRef.current) {
+        setStreamingText(null);
+        setSending(false);
+      }
     }
   };
 
@@ -308,15 +386,20 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
                       : "mr-auto max-w-[85%] bg-accent/5 border border-border rounded-lg px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words"
                   }
                 >
-                  {message.text}
+                  {message.role === "user" ? (
+                    message.text
+                  ) : (
+                    <AssistantText text={message.text} />
+                  )}
                 </div>
               ),
             )}
             {streamingText !== null && (
               <div className="mr-auto max-w-[85%] bg-accent/5 border border-border rounded-lg px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words">
-                {streamingText === "" ? "..." : streamingText}
+                {streamingText === "" ? "..." : <AssistantText text={streamingText} />}
               </div>
             )}
+            <div ref={messagesEndRef} />
           </div>
 
           <form onSubmit={handleSend} className="flex gap-2">

--- a/app/components/ChatInterface.tsx
+++ b/app/components/ChatInterface.tsx
@@ -305,26 +305,8 @@ export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
       )}
 
       {status === "unsupported" && (
-        <div className="p-4 bg-accent/5 border border-border rounded-lg text-sm text-foreground/80 space-y-3">
-          <p className="font-semibold text-foreground">
-            このブラウザではオンデバイスAI (Prompt API) を利用できません。
-          </p>
-          <p>最新のデスクトップ版Chromeで、以下の手順で有効化できます：</p>
-          <ol className="list-decimal list-inside space-y-1 text-xs text-muted-foreground">
-            <li>
-              <code className="font-mono">chrome://flags/#prompt-api-for-gemini-nano</code> を
-              「Enabled」に設定します
-            </li>
-            <li>
-              <code className="font-mono">chrome://flags/#optimization-guide-on-device-model</code>{" "}
-              を「Enabled BypassPerfRequirement」に設定します
-            </li>
-            <li>Chromeを再起動します</li>
-            <li>
-              <code className="font-mono">chrome://components</code> で「Optimization Guide On
-              Device Model」を更新します
-            </li>
-          </ol>
+        <div className="p-4 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm">
+          このブラウザではオンデバイスAI (Prompt API) を利用できません。
         </div>
       )}
 

--- a/app/components/ChatInterface.tsx
+++ b/app/components/ChatInterface.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+  createMcpClient,
+  buildPromptApiTools,
+  type ToolResultEvent,
+} from "@/lib/chat/mcp-bridge";
+
+interface ChatInterfaceProps {
+  onShorten: (shortCode: string, longUrl: string) => void;
+}
+
+/** Prompt API の利用可否〜セッション準備までの状態遷移。 */
+type ChatStatus = "checking" | "unsupported" | "downloadable" | "downloading" | "ready" | "error";
+
+interface ChatMessage {
+  role: "user" | "assistant" | "tool";
+  text: string;
+  toolName?: string;
+}
+
+type MessagesAction = { type: "append"; message: ChatMessage };
+
+function messagesReducer(state: ChatMessage[], action: MessagesAction): ChatMessage[] {
+  switch (action.type) {
+    case "append":
+      return [...state, action.message];
+  }
+}
+
+const SYSTEM_PROMPT =
+  "あなたはURL短縮アシスタントです。" +
+  "URLの短縮を頼まれたら、必ず shorten_url ツールを使って短縮してください。" +
+  "短縮コードから元のURLを調べるよう頼まれたら、必ず resolve_url ツールを使ってください。" +
+  "簡潔に日本語で答えてください。";
+
+/** UrlShortener と同じローディングスピナー。 */
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin h-5 w-5 text-current"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
+    </svg>
+  );
+}
+
+export default function ChatInterface({ onShorten }: ChatInterfaceProps) {
+  const [status, setStatus] = useState<ChatStatus>("checking");
+  const [downloadProgress, setDownloadProgress] = useState(0);
+  const [errorDetail, setErrorDetail] = useState("");
+  const [messages, dispatch] = useReducer(messagesReducer, []);
+  const [streamingText, setStreamingText] = useState<string | null>(null);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const sessionRef = useRef<LanguageModelSession | null>(null);
+  const toolsRef = useRef<LanguageModelTool[] | null>(null);
+
+  // マウント時にPrompt APIの利用可否を判定する
+  useEffect(() => {
+    if (typeof LanguageModel === "undefined") {
+      setStatus("unsupported");
+      return;
+    }
+    let cancelled = false;
+    LanguageModel.availability()
+      .then((availability) => {
+        if (cancelled) return;
+        if (availability === "unavailable") {
+          setStatus("unsupported");
+        } else if (availability === "available") {
+          setStatus("ready");
+        } else {
+          // downloadable / downloading: create() はユーザー操作が必要なのでボタンを出す
+          setStatus("downloadable");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("unsupported");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // アンマウント時にセッションを破棄する
+  useEffect(() => {
+    return () => {
+      sessionRef.current?.destroy();
+      sessionRef.current = null;
+    };
+  }, []);
+
+  const handleToolResult = useCallback(
+    (event: ToolResultEvent) => {
+      dispatch({
+        type: "append",
+        message: { role: "tool", text: event.resultText, toolName: event.toolName },
+      });
+      // 短縮に成功したら履歴（HistoryList）にも反映する
+      if (event.toolName === "shorten_url" && !event.isError) {
+        try {
+          const payload = JSON.parse(event.resultText) as { code?: string; long_url?: string };
+          if (payload.code && payload.long_url) {
+            onShorten(payload.code, payload.long_url);
+          }
+        } catch {
+          // ツール結果がJSONでなければ履歴登録はスキップ
+        }
+      }
+    },
+    [onShorten],
+  );
+
+  /** セッションを遅延生成する。MCPクライアント/ツールも初回のみ生成。 */
+  const ensureSession = useCallback(async (): Promise<LanguageModelSession> => {
+    if (sessionRef.current) return sessionRef.current;
+    if (typeof LanguageModel === "undefined") {
+      throw new Error("Prompt API が利用できません");
+    }
+    if (!toolsRef.current) {
+      const client = await createMcpClient();
+      toolsRef.current = await buildPromptApiTools(client, handleToolResult);
+    }
+    const session = await LanguageModel.create({
+      initialPrompts: [{ role: "system", content: SYSTEM_PROMPT }],
+      tools: toolsRef.current,
+      monitor(m) {
+        m.addEventListener("downloadprogress", (event) => {
+          const loaded = (event as LanguageModelDownloadProgressEvent).loaded;
+          setDownloadProgress(Math.round(loaded * 100));
+        });
+      },
+    });
+    sessionRef.current = session;
+    return session;
+  }, [handleToolResult]);
+
+  const failWithError = (error: unknown) => {
+    setErrorDetail(error instanceof Error ? error.message : String(error));
+    setStatus("error");
+  };
+
+  // モデルのダウンロード（create() はユーザー操作起点で呼ぶ必要がある）
+  const handleDownload = async () => {
+    setDownloadProgress(0);
+    setStatus("downloading");
+    try {
+      await ensureSession();
+      setStatus("ready");
+    } catch (error) {
+      failWithError(error);
+    }
+  };
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || sending) return;
+    setInput("");
+    setSending(true);
+    dispatch({ type: "append", message: { role: "user", text } });
+
+    let session: LanguageModelSession;
+    try {
+      session = await ensureSession();
+    } catch (error) {
+      // セッション生成に失敗（tools未対応バージョン等）した場合はエラーパネルへ
+      failWithError(error);
+      setSending(false);
+      return;
+    }
+
+    try {
+      setStreamingText("");
+      let accumulated = "";
+      const reader = session.promptStreaming(text).getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        accumulated += value;
+        setStreamingText(accumulated);
+      }
+      dispatch({ type: "append", message: { role: "assistant", text: accumulated } });
+    } catch (error) {
+      dispatch({
+        type: "append",
+        message: {
+          role: "assistant",
+          text: `エラーが発生しました: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      });
+    } finally {
+      setStreamingText(null);
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="bg-background rounded-xl shadow-xl hover:shadow-2xl transition-all duration-300 p-8 w-full max-w-md border border-border">
+      <h2 className="text-2xl font-bold text-foreground mb-6 text-center tracking-tight">
+        チャットで短縮
+      </h2>
+
+      {status === "checking" && (
+        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground py-8">
+          <Spinner />
+          利用可能か確認中です...
+        </div>
+      )}
+
+      {status === "unsupported" && (
+        <div className="p-4 bg-accent/5 border border-border rounded-lg text-sm text-foreground/80 space-y-3">
+          <p className="font-semibold text-foreground">
+            このブラウザではオンデバイスAI (Prompt API) を利用できません。
+          </p>
+          <p>最新のデスクトップ版Chromeで、以下の手順で有効化できます：</p>
+          <ol className="list-decimal list-inside space-y-1 text-xs text-muted-foreground">
+            <li>
+              <code className="font-mono">chrome://flags/#prompt-api-for-gemini-nano</code> を
+              「Enabled」に設定します
+            </li>
+            <li>
+              <code className="font-mono">chrome://flags/#optimization-guide-on-device-model</code>{" "}
+              を「Enabled BypassPerfRequirement」に設定します
+            </li>
+            <li>Chromeを再起動します</li>
+            <li>
+              <code className="font-mono">chrome://components</code> で「Optimization Guide On
+              Device Model」を更新します
+            </li>
+          </ol>
+        </div>
+      )}
+
+      {status === "downloadable" && (
+        <div className="space-y-4">
+          <p className="text-sm text-foreground/80">
+            チャットを利用するには、オンデバイスAIモデル (Gemini Nano)
+            のダウンロードが必要です。ダウンロードはこの端末内で一度だけ行われます。
+          </p>
+          <button
+            onClick={handleDownload}
+            className="w-full bg-primary text-primary-foreground font-semibold py-3 rounded-lg hover:opacity-90 transition-all transform active:scale-[0.98]"
+          >
+            モデルをダウンロード
+          </button>
+        </div>
+      )}
+
+      {status === "downloading" && (
+        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground py-8">
+          <Spinner />
+          モデルをダウンロード中です... {downloadProgress}%
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className="p-4 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm space-y-2">
+          <p className="font-semibold">チャットを初期化できませんでした。</p>
+          {errorDetail && <p className="text-xs break-all">{errorDetail}</p>}
+          <p className="text-xs">
+            お使いのChromeのバージョンがPrompt APIのtools機能に未対応の可能性があります。最新版に更新してから再度お試しください。
+          </p>
+        </div>
+      )}
+
+      {status === "ready" && (
+        <div className="space-y-4">
+          <div className="space-y-3 max-h-80 overflow-y-auto" aria-live="polite">
+            {messages.length === 0 && streamingText === null && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                例:「https://example.com を短縮して」と話しかけてください。
+              </p>
+            )}
+            {messages.map((message, index) =>
+              message.role === "tool" ? (
+                <div
+                  key={index}
+                  className="mr-auto max-w-[85%] text-xs text-muted-foreground border border-border rounded-lg px-3 py-2"
+                >
+                  <p className="font-semibold mb-1">ツール実行: {message.toolName}</p>
+                  <pre className="whitespace-pre-wrap break-all font-mono">{message.text}</pre>
+                </div>
+              ) : (
+                <div
+                  key={index}
+                  className={
+                    message.role === "user"
+                      ? "ml-auto max-w-[85%] bg-primary/10 rounded-lg px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words"
+                      : "mr-auto max-w-[85%] bg-accent/5 border border-border rounded-lg px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words"
+                  }
+                >
+                  {message.text}
+                </div>
+              ),
+            )}
+            {streamingText !== null && (
+              <div className="mr-auto max-w-[85%] bg-accent/5 border border-border rounded-lg px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words">
+                {streamingText === "" ? "..." : streamingText}
+              </div>
+            )}
+          </div>
+
+          <form onSubmit={handleSend} className="flex gap-2">
+            <label htmlFor="chat-input" className="sr-only">
+              メッセージを入力
+            </label>
+            <input
+              id="chat-input"
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="短縮したいURLを伝えてください"
+              disabled={sending}
+              className="flex-1 px-4 py-3 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 bg-input text-foreground transition-all disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={sending || !input.trim()}
+              className="bg-primary text-primary-foreground font-semibold px-4 py-3 rounded-lg hover:opacity-90 disabled:opacity-50 transition-all transform active:scale-[0.98]"
+            >
+              {sending ? <Spinner /> : "送信"}
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import UrlShortener from "./components/UrlShortener";
+import ChatInterface from "./components/ChatInterface";
 import HistoryList, { type UrlHistoryItem } from "./components/HistoryList";
 
 const HISTORY_KEY = "url-shortener-history";
 const MAX_HISTORY = 20;
 
+type Tab = "form" | "chat";
+
 export default function Home() {
   const [history, setHistory] = useState<UrlHistoryItem[]>([]);
+  const [tab, setTab] = useState<Tab>("form");
+  // チャットパネルは初回アクティブ化まで遅延マウントし、以降はhiddenで切り替えて
+  // セッション（とTurnstile）の状態を保持する
+  const [chatMounted, setChatMounted] = useState(false);
+  const formTabRef = useRef<HTMLButtonElement>(null);
+  const chatTabRef = useRef<HTMLButtonElement>(null);
 
   // 初期読み込み
   useEffect(() => {
@@ -49,9 +58,82 @@ export default function Home() {
     localStorage.removeItem(HISTORY_KEY);
   };
 
+  const selectTab = (next: Tab) => {
+    setTab(next);
+    if (next === "chat") setChatMounted(true);
+  };
+
+  // 左右矢印キーでタブを移動する（タブは2つなのでトグル）
+  const handleTabKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const next: Tab = tab === "form" ? "chat" : "form";
+    selectTab(next);
+    (next === "form" ? formTabRef : chatTabRef).current?.focus();
+  };
+
+  const tabClass = (selected: boolean) =>
+    `flex-1 px-4 py-2 text-sm transition-colors ${
+      selected
+        ? "border-b-2 border-primary text-primary font-semibold"
+        : "text-muted-foreground hover:text-foreground"
+    }`;
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-primary/20 via-background to-secondary/20 flex flex-col items-center justify-center p-4">
-      <UrlShortener onShorten={handleShorten} />
+      <div
+        role="tablist"
+        aria-label="短縮方法の切り替え"
+        className="w-full max-w-md mb-4 flex border-b border-border"
+        onKeyDown={handleTabKeyDown}
+      >
+        <button
+          ref={formTabRef}
+          role="tab"
+          id="tab-form"
+          aria-selected={tab === "form"}
+          aria-controls="panel-form"
+          tabIndex={tab === "form" ? 0 : -1}
+          onClick={() => selectTab("form")}
+          className={tabClass(tab === "form")}
+        >
+          フォーム
+        </button>
+        <button
+          ref={chatTabRef}
+          role="tab"
+          id="tab-chat"
+          aria-selected={tab === "chat"}
+          aria-controls="panel-chat"
+          tabIndex={tab === "chat" ? 0 : -1}
+          onClick={() => selectTab("chat")}
+          className={tabClass(tab === "chat")}
+        >
+          チャット
+        </button>
+      </div>
+
+      <div
+        id="panel-form"
+        role="tabpanel"
+        aria-labelledby="tab-form"
+        hidden={tab !== "form"}
+        className="w-full max-w-md"
+      >
+        <UrlShortener onShorten={handleShorten} />
+      </div>
+
+      {chatMounted && (
+        <div
+          id="panel-chat"
+          role="tabpanel"
+          aria-labelledby="tab-chat"
+          hidden={tab !== "chat"}
+          className="w-full max-w-md"
+        >
+          <ChatInterface onShorten={handleShorten} />
+        </div>
+      )}
 
       <HistoryList
         history={history}

--- a/lib/api/api-key.ts
+++ b/lib/api/api-key.ts
@@ -11,10 +11,15 @@ export function verifyApiKey(request: NextRequest, apiKey: string | undefined): 
   return timingSafeEqual(Buffer.from(token), Buffer.from(apiKey));
 }
 
-/** APIキーから安定した不透明な識別子を作る（生のキーをKVキーに出さないため）。 */
-export async function apiKeyId(apiKey: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(apiKey));
+/** SHA-256ハッシュを16進文字列で返す。秘匿したい値から不透明な識別子を作るのに使う。 */
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+}
+
+/** APIキーから安定した不透明な識別子を作る（生のキーをKVキーに出さないため）。 */
+export async function apiKeyId(apiKey: string): Promise<string> {
+  return sha256Hex(apiKey);
 }

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -76,7 +76,13 @@ export async function enforceIpRateLimit(
   env: AppEnv,
   request: NextRequest,
 ): Promise<NextResponse | null> {
-  const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  // 本番(Cloudflare)では CF-Connecting-IP が必ず付く。ローカル等それ以外の環境では
+  // X-Forwarded-For の先頭、どちらもなければ "unknown" にフォールバックする
+  // （Next.js 15 では request.ip が廃止されているためヘッダーのみで判定する）。
+  const ip =
+    request.headers.get("CF-Connecting-IP") ??
+    request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim() ??
+    "unknown";
   const store = new D1RateLimitStore(getDb(env));
   return enforceRateLimit(store, `ip:${await sha256Hex(ip)}`);
 }

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -1,8 +1,8 @@
 import { sql } from "drizzle-orm";
-import type { NextResponse } from "next/server";
+import type { NextRequest, NextResponse } from "next/server";
 import { getDb, type AppEnv, type DbClient } from "@/db";
 import { rateLimits } from "@/db/schema/rate-limits";
-import { apiKeyId } from "./api-key";
+import { apiKeyId, sha256Hex } from "./api-key";
 import { apiError } from "./responses";
 
 const WINDOW_SECONDS = 60;
@@ -66,4 +66,17 @@ export async function enforceRateLimit(
 export async function enforceApiRateLimit(env: AppEnv): Promise<NextResponse | null> {
   const store = new D1RateLimitStore(getDb(env));
   return enforceRateLimit(store, await apiKeyId(env.API_KEY!));
+}
+
+/**
+ * 認証なしエンドポイント用: クライアントIP単位でレート制限を判定し、超過なら 429 を返す。
+ * 生のIPをD1に保存しないよう、APIキーと同じ方式（SHA-256）でハッシュ化して識別子にする。
+ */
+export async function enforceIpRateLimit(
+  env: AppEnv,
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  const store = new D1RateLimitStore(getDb(env));
+  return enforceRateLimit(store, `ip:${await sha256Hex(ip)}`);
 }

--- a/lib/chat/mcp-bridge.ts
+++ b/lib/chat/mcp-bridge.ts
@@ -29,7 +29,10 @@ export async function createMcpClient(): Promise<Client> {
  * メタキー（$schema / additionalProperties）はGemini Nano側で解釈されず
  * エラーの原因になり得るため取り除く（type / properties / required / description は残す）。
  */
-function sanitizeInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+function sanitizeInputSchema(
+  schema: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!schema) return {};
   const { $schema: _schema, additionalProperties: _additional, ...rest } = schema;
   return rest;
 }

--- a/lib/chat/mcp-bridge.ts
+++ b/lib/chat/mcp-bridge.ts
@@ -1,0 +1,92 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+/**
+ * Prompt API (Gemini Nano) と自前のMCPサーバーをつなぐブラウザ側ブリッジ。
+ * Reactに依存しない純粋ロジックとして切り出し、単体テスト可能にしている。
+ */
+
+/** ツール呼び出し結果の通知。UIがツールバブル表示や履歴登録に使う。 */
+export interface ToolResultEvent {
+  toolName: string;
+  args: Record<string, unknown>;
+  resultText: string;
+  isError: boolean;
+}
+
+/** チャットUI用の認証なしMCPプロキシ (/api/chat/mcp) に接続したクライアントを返す。 */
+export async function createMcpClient(): Promise<Client> {
+  const client = new Client({ name: "url-shortener-chat", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(
+    new URL("/api/chat/mcp", window.location.origin),
+  );
+  await client.connect(transport);
+  return client;
+}
+
+/**
+ * MCPのinputSchemaをPrompt APIが受け付ける形に整える。
+ * メタキー（$schema / additionalProperties）はGemini Nano側で解釈されず
+ * エラーの原因になり得るため取り除く（type / properties / required / description は残す）。
+ */
+function sanitizeInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const { $schema: _schema, additionalProperties: _additional, ...rest } = schema;
+  return rest;
+}
+
+/** MCPツール呼び出しの content からテキスト部分だけを結合して取り出す。 */
+function joinTextContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (item): item is { type: "text"; text: string } =>
+        typeof item === "object" &&
+        item !== null &&
+        (item as { type?: unknown }).type === "text" &&
+        typeof (item as { text?: unknown }).text === "string",
+    )
+    .map((item) => item.text)
+    .join("\n");
+}
+
+/** 通信エラーをモデルに伝えられる日本語メッセージへ変換する（throwしない方針）。 */
+function describeTransportError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("429")) {
+    return "リクエストが多すぎます。しばらく待ってから再試行してください";
+  }
+  return `ツールの呼び出しに失敗しました: ${message}`;
+}
+
+/**
+ * MCPサーバーのツール一覧を取得し、Prompt APIの tools オプションに渡せる形へ変換する。
+ * 各ツールの実行は MCP の tools/call にプロキシし、結果のテキストを返す。
+ * エラー時もthrowせず日本語のエラーメッセージ文字列を返すことで、モデルが
+ * そのままユーザーへ伝えられるようにする。
+ */
+export async function buildPromptApiTools(
+  client: Client,
+  onToolResult: (event: ToolResultEvent) => void,
+): Promise<LanguageModelTool[]> {
+  const { tools } = await client.listTools();
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description ?? "",
+    inputSchema: sanitizeInputSchema(tool.inputSchema as Record<string, unknown>),
+    async execute(args: Record<string, unknown>): Promise<string> {
+      let resultText: string;
+      let isError: boolean;
+      try {
+        const result = await client.callTool({ name: tool.name, arguments: args });
+        isError = result.isError === true;
+        const text = joinTextContent(result.content);
+        resultText = isError ? `エラー: ${text}` : text;
+      } catch (error) {
+        isError = true;
+        resultText = describeTransportError(error);
+      }
+      onToolResult({ toolName: tool.name, args, resultText, isError });
+      return resultText;
+    },
+  }));
+}

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -1,0 +1,91 @@
+import { createMcpHandler } from "mcp-handler";
+import { z } from "zod";
+import { validateShortenRequest } from "@/lib/validations/url";
+import { linkPayload } from "@/lib/api/responses";
+import type { AppEnv } from "@/db";
+import { buildService } from "@/lib/core/build";
+import { ShortenError } from "@/lib/core/errors";
+
+/** MCPツールが返すテキストコンテンツを組み立てる。 */
+function textResult(payload: unknown, isError = false) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: typeof payload === "string" ? payload : JSON.stringify(payload, null, 2),
+      },
+    ],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+/**
+ * Stateless な Streamable HTTP MCP ハンドラを組み立てる。
+ *
+ * 実装メモ:
+ * - `mcp-handler` (Vercel MCP Adapter) を採用。v1.1.0 は MCP SDK の
+ *   `WebStandardStreamableHTTPServerTransport`（Web標準 Request/Response ベース）を
+ *   使うため、Cloudflare Workers (V8 isolate + nodejs_compat) でも動作する。
+ *   Node の `http` サーバーを前提とする経路は SSE トランスポートのみで、
+ *   `disableSse: true` により無効化している（Redis も不要になる）。
+ * - `env` はリクエストごとに `getCloudflareContext()` から取得する必要があるため、
+ *   ハンドラはモジュールスコープではなくリクエストごとに生成する。
+ *   stateless（セッションなし）運用なので毎回生成してもインスタンス状態に依存しない。
+ * - 認証・レート制限はここでは行わない。呼び出し元のルート
+ *   （/mcp は APIキー認証、/api/chat/mcp はIPレート制限）が責務を持つ。
+ * - `mcp-handler` はリクエストパスを `${basePath}/mcp` と照合するため、
+ *   マウント先に応じた basePath を渡す（/mcp は ""、/api/chat/mcp は "/api/chat"）。
+ */
+export function buildMcpHandler(env: AppEnv, origin: string, basePath = "") {
+  return createMcpHandler(
+    (server) => {
+      server.tool(
+        "shorten_url",
+        "URLを短縮し、短縮URLを返します。既に登録済みのURLの場合は既存の短縮URLを返します。",
+        { url: z.string().describe("短縮したいURL (http/https)") },
+        async ({ url }) => {
+          const result = validateShortenRequest({ url });
+          if (!result.success) {
+            return textResult(result.error.errors[0].message, true);
+          }
+          try {
+            const { record, isExisting } = await buildService(env).create(result.data.url);
+            // KVキャッシュは登録時には書かない。リダイレクト側のread-through
+            // (app/[code]/route.ts) が初回アクセス時に充填する。
+            return textResult({ ...linkPayload(origin, record), isExisting });
+          } catch (error) {
+            if (error instanceof ShortenError && error.code === "UNSAFE_URL") {
+              return textResult(
+                `このURLは安全ではない可能性があるため登録できません (threatType: ${error.detail?.threatType})`,
+                true,
+              );
+            }
+            throw error;
+          }
+        },
+      );
+
+      server.tool(
+        "resolve_url",
+        "短縮コードから元のURLを取得します。",
+        { code: z.string().describe("短縮コード (例: abc123)") },
+        async ({ code }) => {
+          const record = await buildService(env).get(code);
+          if (!record) {
+            return textResult("指定された短縮コードは存在しません", true);
+          }
+          return textResult(linkPayload(origin, record));
+        },
+      );
+    },
+    {
+      serverInfo: { name: "url-shortener", version: "1.0.0" },
+    },
+    {
+      basePath, // エンドポイントは `${basePath}/mcp`
+      disableSse: true, // stateless運用。SSE(GET)は使わないのでRedisも不要
+      maxDuration: 30,
+      verboseLogs: false,
+    },
+  );
+}

--- a/types/dom-chromium-ai.d.ts
+++ b/types/dom-chromium-ai.d.ts
@@ -38,9 +38,14 @@ interface LanguageModelCreateOptions {
   signal?: AbortSignal;
 }
 
-/** create() の monitor に届く "downloadprogress" イベント。loaded は 0〜1 の進捗率。 */
+/**
+ * create() の monitor に届く "downloadprogress" イベント。
+ * 現行仕様では loaded は 0〜1 の進捗率（total は廃止済み）だが、
+ * 古い実装ではバイト数 + total が来るため、互換のため optional で持つ。
+ */
 interface LanguageModelDownloadProgressEvent extends Event {
   loaded: number;
+  total?: number;
 }
 
 declare const LanguageModel:

--- a/types/dom-chromium-ai.d.ts
+++ b/types/dom-chromium-ai.d.ts
@@ -1,0 +1,51 @@
+/**
+ * Chrome Prompt API (Gemini Nano / LanguageModel) の最小限の手書き型定義。
+ * https://developer.chrome.com/docs/ai/prompt-api
+ *
+ * 実験的APIで公式の @types が安定していないため、本プロジェクトで使う範囲のみ宣言する
+ * （新しい依存を増やさない・tsconfig の types 配列も変更しない方針）。
+ * 未対応ブラウザではグローバルが存在しないため、`typeof LanguageModel === "undefined"`
+ * で判定できるよう `| undefined` を含めて宣言している。
+ */
+
+type LanguageModelAvailability = "unavailable" | "downloadable" | "downloading" | "available";
+
+/** Prompt API に渡すツール定義（MCPツールをブリッジする）。 */
+interface LanguageModelTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute(args: Record<string, unknown>): Promise<string>;
+}
+
+interface LanguageModelInitialPrompt {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+interface LanguageModelSession {
+  prompt(input: string): Promise<string>;
+  promptStreaming(input: string): ReadableStream<string>;
+  inputUsage: number;
+  inputQuota: number;
+  destroy(): void;
+}
+
+interface LanguageModelCreateOptions {
+  initialPrompts?: LanguageModelInitialPrompt[];
+  tools?: LanguageModelTool[];
+  monitor?(m: EventTarget): void;
+  signal?: AbortSignal;
+}
+
+/** create() の monitor に届く "downloadprogress" イベント。loaded は 0〜1 の進捗率。 */
+interface LanguageModelDownloadProgressEvent extends Event {
+  loaded: number;
+}
+
+declare const LanguageModel:
+  | {
+      availability(): Promise<LanguageModelAvailability>;
+      create(options?: LanguageModelCreateOptions): Promise<LanguageModelSession>;
+    }
+  | undefined;


### PR DESCRIPTION
## 概要

Linear [UNI-102](https://linear.app/uni-3/issue/UNI-102/チャット操作のインターフェイスつくる): トップページにチャットUIを追加し、自然言語でURL短縮・解決を操作できるようにする。

## 構成

```
ブラウザ                                  Worker
┌─────────────────────────┐
│ Gemini Nano (Prompt API)│
│  └ tool execute()       │   MCP JSON-RPC（認証なし）
│     └ MCPクライアント ──────→ /api/chat/mcp ── IPレートリミット
└─────────────────────────┘        └ buildMcpHandler（/mcp と共有）
```

## 変更内容

- **チャットUI** (`app/components/ChatInterface.tsx`): ブラウザ標準LLM（Chrome Prompt API / Gemini Nano）を使用。モデル未対応ブラウザにはフォールバックパネル、モデルDLは進捗%表示、応答はストリーミング描画。`shorten_url` 成功時は既存のlocalStorage履歴にも反映
- **タブ切り替え** (`app/page.tsx`): フォーム ⇔ チャット（デフォルト: フォーム）。role=tablist/tab/tabpanel + 矢印キー対応。パネルは `hidden` 切替で状態保持（Turnstile/チャットセッション維持）
- **MCPプロキシ** (`app/api/chat/mcp/route.ts`): 認証なしエンドポイント。APIキーはブラウザに出さず、`CF-Connecting-IP` のSHA-256ハッシュ単位で既存D1レートリミット（60req/分）を適用
- **MCPハンドラ共有化** (`lib/mcp/handler.ts`): `/mcp` から抽出。`/mcp` のBearer認証・レートリミット・挙動は不変（既存テスト11件パス）
- **ブリッジ** (`lib/chat/mcp-bridge.ts`): `listTools()` でMCPツール→Prompt APIツールへ動的変換。スキーマの `$schema`/`additionalProperties` 除去、エラーは文字列でモデルに返却

## テスト

- 新規: chat-mcp-route 7件 / mcp-bridge 7件 / ChatInterface 3件、Home.test.tsx にタブ切替テスト追加
- `pnpm type-check` ✅ / `pnpm build` ✅ / テスト 100件パス（jsdom系のローカル実行は `node:crypto` のvitest externalize問題の回避設定で確認。CIが正）

## 動作確認手順

Chrome で `chrome://flags/#prompt-api-for-gemini-nano` と `chrome://flags/#optimization-guide-on-device-model` (BypassPerfRequirement) を有効化 → チャットタブで「https://example.com を短縮して」

## 備考

- 認証なしエンドポイントの濫用はIPレートリミットのみで保護（要件として了承済み）。Safe Browsing検証はサービス層で全リクエストに有効
- ローカル `pnpm test` が赤くなる既知問題の根本原因は Node バージョンではなく `__tests__/setup.ts` 等の `node:crypto` import が vitest jsdom transform で externalize されることと判明（別PRで対応可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)